### PR TITLE
feat: add goreleaser for binary releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+  categories:
+    - title: New Features
+      labels:
+        - "Type: Enhancement"
+    - title: Bug Fixes
+      labels:
+        - "Type: Bug"
+    - title: Maintenance
+      labels:
+        - "Type: Maintenance"
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -1,0 +1,30 @@
+name: Release Binary
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check out code"
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: "Set up Go"
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.x
+
+      - name: "Create release on GitHub"
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          args: "release --clean"
+          version: latest
+          workdir: .
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,0 +1,28 @@
+name: Release Test
+
+on:
+  pull_request:
+    paths:
+      - '**.go'
+      - '**.mod'
+  workflow_dispatch:
+
+jobs:
+  release-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check out code"
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.x
+
+      - name: release test
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          args: "release --clean --snapshot"
+          version: latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/jswhois

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,32 @@
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - 386
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: '386'
+      - goos: windows
+        goarch: 'arm'
+      - goos: windows
+        goarch: 'arm64'
+    binary: '{{ .ProjectName }}'
+    main: ./jswhois.go
+
+archives:
+- format: zip
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
+
+checksum:
+  algorithm: sha256

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/jschauma/jswhois
+module github.com/freelabz/jswhois
 
 go 1.22.4

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/freelabz/jswhois
+module github.com/jschauma/jswhois
 
 go 1.22.4


### PR DESCRIPTION
## Summary
- Adds goreleaser configuration and GitHub Actions workflows for automated binary releases
- Enables cross-platform binary distribution (Linux, macOS, Windows) via GitHub Releases
- Adds release testing workflow for PRs touching Go source files
- Adds `.gitignore` for build artifacts

## Test plan
- [x] `go build` succeeds
- [ ] Tag a release to trigger goreleaser workflow